### PR TITLE
allow backslashes in return types to support namespaced classes

### DIFF
--- a/src/functionParser.js
+++ b/src/functionParser.js
@@ -53,7 +53,7 @@ function getReturns(text) {
         //read to end of string
         var index = lastIndex + 1;
         var splicedText = text.slice(index, text.length);
-        returnText = splicedText.match(/[a-zA-Z][a-zA-Z0-9$_]*/).toString();
+        returnText = splicedText.match(/[a-zA-Z][a-zA-Z0-9$_\\]*/).toString();
     }
     return returnText;
 }


### PR DESCRIPTION
for #3 so returntypes in docblocks will contain namespaces of classes