### PR TITLE
Fix: plugin doesn't read muliline params

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -12,8 +12,24 @@ function activate(context) {
         if (lang == "php") {
             var selection = vscode.window.activeTextEditor.selection;
             var startLine = selection.start.line;
-            var selectedText = vscode.window.activeTextEditor.document.lineAt(startLine).text;
+            var editor = vscode.window.activeTextEditor;
 
+            // Read all lines that belong to the function signature
+            var selectedText = '';
+            var currentLine = startLine;
+
+            // Continue reading lines until we close the parentheses
+            while (currentLine < editor.document.lineCount) {
+                const lineText = editor.document.lineAt(currentLine).text;
+                selectedText += lineText.trim(); // Add the line text, removing extra spaces
+                currentLine++;
+
+                // Break the loop if the function signature is complete
+                if (selectedText.includes(')')) {
+                    break;
+                }
+            }
+            
             var textToInsert = '';
             if (/function\s+([\w_-]+)/.exec(selectedText) != null) {
                 textToInsert = method.comment(selectedText);

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
         "@types/node": "^7.10.9",
         "eslint": "^4.11.0",
         "typescript": "^2.6.1",
-        "vscode": "^1.1.36"
+        "vscode": "^1.1.37"
     }
 }


### PR DESCRIPTION
Summary

This pull request addresses the issue where the extension could only handle single-line function parameter definitions in PHP. It introduces logic to process multi-line function signatures correctly.

Changes Made:
The code now reads all lines that belong to a PHP function signature until the closing parenthesis ) is found. This ensures that multi-line function parameter definitions are supported.

Related Issue

This resolves the issue described in #15 

Testing

    Tested with single-line function signatures.
    Tested with multi-line function signatures, ensuring parameters were captured correctly.


Let me know if you'd like me to refine this further!